### PR TITLE
Implement basic fetch TODO list

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
-import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
+import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
+import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 
 plugins {
     kotlin("jvm") version "1.8.21"
@@ -10,31 +12,34 @@ repositories {
 
 dependencies {
     val http4kVersion = project.properties["http4kVersion"].toString()
-    val junitVersion = project.properties["junitVersion"].toString()
-    val junitLauncherVersion = project.properties["junitLauncherVersion"].toString()
+    val kotestVersion = project.properties["kotestVersion"].toString()
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 
-    implementation("org.http4k:http4k-core:${http4kVersion}")
-    implementation("org.http4k:http4k-server-jetty:${http4kVersion}")
+    implementation("org.http4k:http4k-core:$http4kVersion")
+    implementation("org.http4k:http4k-server-jetty:$http4kVersion")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:${junitLauncherVersion}")
-    testImplementation("org.http4k:http4k-client-jetty:${http4kVersion}")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest:kotest-property:$kotestVersion")
+    testImplementation("org.http4k:http4k-client-jetty:$http4kVersion")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 tasks {
     test {
         useJUnitPlatform()
         testLogging {
-            events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+            events = setOf(PASSED, SKIPPED, FAILED)
         }
 
-        //if true show println in test console
+        // if true show println in test console
         testLogging.showStandardStreams = false
 
         // start tests every time, even when code not changed
         outputs.upToDateWhen { false }
-
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,5 @@ org.gradle.caching=true
 org.gradle.parallel=false
 kotlin.incremental=true
 #versions
+kotestVersion=5.6.2
 http4kVersion=4.14.0.0
-junitVersion=5.9.3
-junitLauncherVersion=1.9.3

--- a/src/main/kotlin/com/yonatankarp/zettai/Main.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/Main.kt
@@ -1,3 +1,0 @@
-package com.yonatankarp.zettai
-
-fun main() = println("Hello, world!")

--- a/src/main/kotlin/com/yonatankarp/zettai/domain/ToDoList.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/domain/ToDoList.kt
@@ -1,0 +1,26 @@
+package com.yonatankarp.zettai.domain
+
+/**
+ * A ToDoList contains a list name and a list of ToDoItems
+ */
+data class ToDoList(val listName: ListName, val items: List<ToDoItem>)
+
+/**
+ * A ToDoItem contains a description string
+ */
+data class ListName(val name: String)
+
+/**
+ * A ToDoItem contains a description string
+ */
+data class ToDoItem(val description: String)
+
+/**
+ * The status of a given ToDoItem
+ */
+enum class ToDoStatus {
+    Todo,
+    InProgress,
+    Done,
+    Blocked
+}

--- a/src/main/kotlin/com/yonatankarp/zettai/domain/User.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/domain/User.kt
@@ -1,0 +1,6 @@
+package com.yonatankarp.zettai.domain
+
+/**
+ * A User contains a user name
+ */
+data class User(val name: String)

--- a/src/main/kotlin/com/yonatankarp/zettai/ui/HtmlPage.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/ui/HtmlPage.kt
@@ -1,0 +1,3 @@
+package com.yonatankarp.zettai.ui
+
+data class HtmlPage(val raw: String)

--- a/src/main/kotlin/com/yonatankarp/zettai/utils/Functional.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/utils/Functional.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.zettai.utils
+
+typealias FUN<A, B> = (A) -> B
+
+/**
+ * Composes two functions together.
+ */
+infix fun <A, B, C> FUN<A, B>.andThen(f: FUN<B, C>): FUN<A, C> = { a: A -> f(this(a)) }

--- a/src/main/kotlin/com/yonatankarp/zettai/webservice/Main.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/webservice/Main.kt
@@ -1,0 +1,17 @@
+package com.yonatankarp.zettai.webservice
+
+import com.yonatankarp.zettai.domain.ListName
+import com.yonatankarp.zettai.domain.ToDoItem
+import com.yonatankarp.zettai.domain.ToDoList
+import com.yonatankarp.zettai.domain.User
+import org.http4k.server.Jetty
+import org.http4k.server.asServer
+
+fun main() {
+    val items = listOf("write chapter", "insert code", "draw diagrams")
+    val todoList = ToDoList(ListName("book"), items.map(::ToDoItem))
+    val lists = mapOf(User("uberto") to listOf(todoList))
+    Zettai(lists).asServer(Jetty(8080)).start()
+
+    println("Server started at http://localhost:8080/todo/uberto/book")
+}

--- a/src/main/kotlin/com/yonatankarp/zettai/webservice/Zettai.kt
+++ b/src/main/kotlin/com/yonatankarp/zettai/webservice/Zettai.kt
@@ -1,0 +1,70 @@
+package com.yonatankarp.zettai.webservice
+
+import com.yonatankarp.zettai.domain.ListName
+import com.yonatankarp.zettai.domain.ToDoItem
+import com.yonatankarp.zettai.domain.ToDoList
+import com.yonatankarp.zettai.domain.User
+import com.yonatankarp.zettai.ui.HtmlPage
+import com.yonatankarp.zettai.utils.andThen
+import org.http4k.core.HttpHandler
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.routing.bind
+import org.http4k.routing.path
+import org.http4k.routing.routes
+
+class Zettai(val lists: Map<User, List<ToDoList>>) : HttpHandler {
+
+    val routes = routes(
+        "/todo/{user}/{list}" bind Method.GET to ::getToDoList
+    )
+
+    override fun invoke(request: Request): Response =
+        routes(request)
+
+
+    /**
+     * Process a ToDoList request.
+     */
+    val processFunction = ::extractListData andThen
+            ::fetchListContent andThen
+            ::renderHtml andThen
+            ::createResponse
+
+    private fun getToDoList(req: Request): Response = processFunction(req)
+
+    private fun extractListData(req: Request): Pair<User, ListName> {
+        val user = req.path("user").orEmpty()
+        val list = req.path("list").orEmpty()
+        return User(user) to ListName(list)
+    }
+
+    private fun fetchListContent(listId: Pair<User, ListName>): ToDoList =
+        lists[listId.first]
+            ?.firstOrNull { it.listName == listId.second }
+            ?: error("List unknown")
+
+    private fun renderHtml(list: ToDoList): HtmlPage = HtmlPage(
+        """
+        <html>
+            <body>
+                <h1>Zettai</h1>
+                <h2>${list.listName.name}</h2>
+                <table>
+                    <tbody>${renderItems(list.items)}</tbody>
+                </table>
+            </body>
+        </html>
+        """.trimIndent()
+    )
+
+    private fun renderItems(items: List<ToDoItem>): String = items.map {
+        """
+        <tr><td>${it.description}</td></tr>
+        """.trimIndent()
+    }.joinToString("")
+
+    private fun createResponse(html: HtmlPage): Response = Response(OK).body(html.raw)
+}

--- a/src/test/kotlin/com/yonatankarp/zettai/stories/SeeATodoListAt.kt
+++ b/src/test/kotlin/com/yonatankarp/zettai/stories/SeeATodoListAt.kt
@@ -1,0 +1,79 @@
+package com.yonatankarp.zettai.stories
+
+import com.yonatankarp.zettai.domain.ListName
+import com.yonatankarp.zettai.domain.ToDoItem
+import com.yonatankarp.zettai.domain.ToDoList
+import com.yonatankarp.zettai.domain.User
+import com.yonatankarp.zettai.webservice.Zettai
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.http4k.client.JettyClient
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Status
+import org.http4k.server.Jetty
+import org.http4k.server.asServer
+
+private const val port = 8081
+
+@Suppress("SameParameterValue")
+private fun startTheApplication(user: String, listName: String, items: List<String>) {
+    val toDoList = ToDoList(ListName(listName), items.map { ToDoItem(it) })
+    val lists = mapOf(User(user) to listOf(toDoList))
+    val server = Zettai(lists).asServer(Jetty(port)) // port different from main
+    server.start()
+}
+
+@Suppress("SameParameterValue")
+private fun getToDoList(user: String, listName: String): ToDoList {
+    val client = JettyClient()
+
+    val request = Request(Method.GET, "http://localhost:$port/todo/$user/$listName")
+    val response = client(request)
+
+    return if (response.status == Status.OK) parseResponse(response.bodyString())
+    else fail(response.toMessage())
+}
+
+private fun parseResponse(html: String): ToDoList {
+    val nameRegex = "<h2>.*<".toRegex()
+    val listName = ListName(extractListName(nameRegex, html))
+    val itemsRegex = "<td>.*?<".toRegex()
+    val items = itemsRegex
+        .findAll(html)
+        .map { ToDoItem(extractItemDesc(it)) }
+        .toList()
+    return ToDoList(listName, items)
+}
+
+private fun extractListName(nameRegex: Regex, html: String): String =
+    nameRegex.find(html)?.value
+        ?.substringAfter("<h2>")
+        ?.dropLast(1)
+        .orEmpty()
+
+private fun extractItemDesc(matchResult: MatchResult): String =
+    matchResult.value
+        .substringAfter("<td>")
+        .dropLast(1)
+
+class SeeATodoListAt : BehaviorSpec({
+    given("List owners can see their lists") {
+        val user = "frank"
+        val listName = "shopping"
+        val foodToBuy = listOf("carrots", "apples", "milk")
+
+        startTheApplication(user, listName, foodToBuy)
+
+        `when`("User fetch list by name") {
+
+            val list = getToDoList(user, listName)
+
+            then("List name is correctly fetched and all items exists") {
+                list.listName.name shouldBe listName
+                list.items.map { it.description } shouldBe foodToBuy
+            }
+        }
+    }
+})


### PR DESCRIPTION
This commit adds a basic implementation of fetching and rendering a TODO list of a user into HTML page to serve it.

The current implementation works only with a hard-coded values that would be replaced later on with values that are fetched from a storage.