### PR TITLE
Improve DDT execution based on AbstractDDT

### DIFF
--- a/src/test/kotlin/com/yonatankarp/zettai/ddt/AbstractDDT.kt
+++ b/src/test/kotlin/com/yonatankarp/zettai/ddt/AbstractDDT.kt
@@ -7,9 +7,18 @@ import com.yonatankarp.zettai.ddt.actions.ZettaiActions
 
 typealias ZettaiDDT = DomainDrivenTest<ZettaiActions>
 
-fun allActions() = setOf(
-    DomainOnlyActions(),
-    HttpActions(),
-)
+internal val allActions: Set<ZettaiActions>
+    get() = setOf(
+        DomainOnlyActions(),
+        HttpActions(),
+    )
 
-abstract class AbstractDDT : ZettaiDDT(allActions())
+@Suppress("unused")
+internal val domainOnlyActions: Set<ZettaiActions>
+    get() = setOf(DomainOnlyActions())
+
+@Suppress("unused")
+internal val httpActions: Set<ZettaiActions>
+    get() = setOf(HttpActions())
+
+abstract class AbstractDDT(actions: Set<ZettaiActions> = allActions) : ZettaiDDT(actions)


### PR DESCRIPTION


# Purpose

This commit adds a parameter to the `AbstractDDT` that allows executing the domain or HTTP only separately for debugging

# Changes

Any DDT test can now pass a parameter to the `AbstractDDT` test and configure running only the `domain` or only `HTTP` test